### PR TITLE
fix: skip inner function structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ h := H{
 
 ## Rules
 
-- `zerovalue_struct`: ban incomplete struct initialization 
+- `zerovalue_struct`: ban incomplete struct initialization (inner function structs are not supported)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 ```sh
 $ go run github.com/matsuri-tech/golint-extra ./...
+
+# Or you just want to see logs:
+$ DEBUG=true go run github.com/matsuri-tech/golint-extra ./...
 ```
 
 ## Ignore lint

--- a/example/zerovalue_struct_test.go
+++ b/example/zerovalue_struct_test.go
@@ -30,7 +30,7 @@ func NoFieldsExample_success() {
 
 // An example using multiple functions
 
-func Ex1() string {
+func Ex1_success() string {
 	// Inner function struct
 	type A struct {
 		a string
@@ -43,7 +43,7 @@ func Ex1() string {
 	return a.a
 }
 
-func Ex2() int {
+func Ex2_success() int {
 	// Inner function struct
 	type A struct {
 		b int

--- a/example/zerovalue_struct_test.go
+++ b/example/zerovalue_struct_test.go
@@ -23,3 +23,35 @@ func IncompleteStructExample_fail() H {
 
 	return h
 }
+
+func NoFieldsExample_success() {
+	_ = H{}
+}
+
+// An example using multiple functions
+
+func Ex1() string {
+	// Inner function struct
+	type A struct {
+		a string
+	}
+
+	a := A{
+		a: "foo",
+	}
+
+	return a.a
+}
+
+func Ex2() int {
+	// Inner function struct
+	type A struct {
+		b int
+	}
+
+	a := A{
+		b: 200,
+	}
+
+	return a.b
+}

--- a/main.go
+++ b/main.go
@@ -3,9 +3,18 @@ package main
 import (
 	"github.com/matsuri-tech/golint-extra/rules"
 	"golang.org/x/tools/go/analysis/multichecker"
+	"io/ioutil"
+	"log"
+	"os"
 )
 
 func main() {
+	if os.Getenv("DEBUG") != "true" {
+		log.SetOutput(ioutil.Discard)
+	} else {
+		log.SetOutput(os.Stdout)
+	}
+
 	multichecker.Main(
 		rules.NewZeroValueStruct(),
 	)

--- a/rules/zerovalue_struct.go
+++ b/rules/zerovalue_struct.go
@@ -165,7 +165,16 @@ func run(pass *analysis.Pass) (interface{}, error) {
 
 			var keys []string
 			for _, e := range expr.Elts {
-				keys = append(keys, e.(*ast.KeyValueExpr).Key.(*ast.Ident).Name)
+				key := e.(*ast.KeyValueExpr).Key
+				ident, ok := key.(*ast.Ident)
+				if !ok {
+					log.Printf("Found a non ident key: %+v\n", key)
+					ast.Fprint(log.Writer(), &token.FileSet{}, expr, ast.NotNilFilter)
+
+					return
+				}
+
+				keys = append(keys, ident.Name)
 			}
 
 			expected := rc[p.String()]
@@ -192,9 +201,9 @@ func run(pass *analysis.Pass) (interface{}, error) {
 
 func NewZeroValueStruct() *analysis.Analyzer {
 	return &analysis.Analyzer{
-		Name: "zerovalue_struct",
-		Doc:  "zerovalue-struct",
-		Run:  run,
+		Name:     "zerovalue_struct",
+		Doc:      "zerovalue-struct",
+		Run:      run,
 		Requires: []*analysis.Analyzer{inspect.Analyzer},
 	}
 }

--- a/rules/zerovalue_struct.go
+++ b/rules/zerovalue_struct.go
@@ -69,6 +69,8 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		switch decl := n.(type) {
 		case *ast.GenDecl:
 			if decl.Tok.IsKeyword() && decl.Tok.String() == "type" {
+				// 関数内の構造体は同名で複数の構造体が定義されている場合があるので無視する
+				// パッケージ内に定義されている場合は、exposeしていなくても同名の定義はできないのでこのような問題は起きない
 				if prevFuncPos != nil && prevFuncEnd != nil && *prevFuncPos < decl.Pos() && decl.End() < *prevFuncEnd {
 					log.Printf("Found inner function struct %+v, skipping...\n", decl.Specs[0].(*ast.TypeSpec).Name)
 					return

--- a/rules/zerovalue_struct.go
+++ b/rules/zerovalue_struct.go
@@ -157,7 +157,6 @@ func run(pass *analysis.Pass) (interface{}, error) {
 				return
 			}
 
-			result = append(result, errors.New(fmt.Sprintf("%+v", keys)))
 			return
 		}
 	})


### PR DESCRIPTION
## Why
Closes: #7 

## What
- 関数内で定義された構造体は扱いが難しいのでチェックを全てスキップするようにしました(ちゃんとやるならレキシカルスコープを計算しないといけないがやりたくないので…)
- ログの出力をデフォルトで抑制したかったので雑にDEBUGモードを実装
