### PR TITLE
ci: generate-release-notes アクションの指定を @v3 に統一

### DIFF
--- a/.github/workflows/release-note.yml
+++ b/.github/workflows/release-note.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: matsuri-tech/generate-release-notes-body-based-on-pull-requests@d75bba1db6f5c7d9038e0c026d4f37a4c30edbaa # v3.1.0
+      - uses: matsuri-tech/generate-release-notes-body-based-on-pull-requests@v3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_PREFIX: "Release Note"


### PR DESCRIPTION
`matsuri-tech/generate-release-notes-body-based-on-pull-requests` の参照を `@d75bba1db6f5c7d9038e0c026d4f37a4c30edbaa` から `@v3` に変更します。

## 背景・方針
- 本 action は社内（matsuri-tech）リポジトリのものであり、サプライチェーン上のリスクは十分に低い。
- 一般にはコミットハッシュ固定が推奨されるが、修正を即座に全リポジトリへ展開できることを優先し、移動 ref（`v3`）に統一する。
- `v3` はメジャー系列を追従するため、将来 `v4` が公開されても破壊的変更を自動では取り込まない。
- 現時点で `v3` と `main` は同一内容であり、`v2` → `v3` も入力インターフェースは互換（任意入力 `AUTO_MERGE_ACTOR` が追加されたのみ）。

## 変更内容
- `.github/workflows/release-note.yml`: `@d75bba1db6f5c7d9038e0c026d4f37a4c30edbaa` → `@v3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)