### PR TITLE
chore(deps): restrict matsuri-tech action updates to major only

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,6 +30,12 @@
       "matchDepTypes": ["action"],
       "matchPackageNames": ["actions/{/,}**", "matsuri-tech/{/,}**"],
       "pinDigests": false
+    },
+    {
+      "matchDepTypes": ["action"],
+      "matchPackageNames": ["matsuri-tech/{/,}**"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
matsuri-tech org が管理する GitHub Actions / reusable workflow について、minor / patch の Renovate 更新 PR を抑止し、メジャー(破壊的変更)更新のみ通知するようにします。

## 変更内容

`renovate.json` の `packageRules`(トップレベル)に以下を追加します。

```json
{
  "matchDepTypes": ["action"],
  "matchPackageNames": ["matsuri-tech/{/,}**"],
  "matchUpdateTypes": ["minor", "patch"],
  "enabled": false
}
```

## 背景・意図

- `matsuri-tech/generate-release-notes-body-based-on-pull-requests` などの内部 action の minor / patch bump が、各 repo に頻繁に Renovate PR を作成していました。
- これらは org 側で管理しているため、各 repo では **メジャー(破壊的変更)更新のみ** を受け取れば十分です。
- 既存の `pinDigests: false`(タグ参照)はそのまま維持します。メジャー更新（例: `v3` → `v4`）の Renovate PR は引き続き作成されます。

org 配下の `renovate.json` を持つ各リポジトリへ横断的に同じ変更を適用しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
